### PR TITLE
Update badge URLs

### DIFF
--- a/Project Maturity/readme.md
+++ b/Project Maturity/readme.md
@@ -4,44 +4,42 @@ Software maturity refers to the stages a software project goes through during it
 
 # Graduated
 
-![Static Badge](./graduated_badge.svg)
-
-
+![Static Badge](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/graduated_badge.svg)
 
 Graduated projects are ready for operations, and typically used by ECMWF and/or its Member and Cooperating states in operations. This does not mean we give operational support to the software itself.
 
-    https://raw.githubusercontent.com/ecmwf/codex/refs/heads/main/codex/Project%20Maturity/graduated_badge.svg
+    https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/graduated_badge.svg
 
 # Incubating
 
-![Static Badge](./incubating_badge.svg)
+![Static Badge](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/incubating_badge.svg)
 
 Incubating projects are mostly feature-complete and the interface is mostly stable. However, they are still under development and should not be used for operational or time-critical applications.
 
-    https://raw.githubusercontent.com/ecmwf/codex/refs/heads/main/codex/Project%20Maturity/incubating_badge.svg
+    https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/incubating_badge.svg
 
 # Emerging
 
-![Static Badge](./emerging_badge.svg)
+![Static Badge](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/emerging_badge.svg)
 
 Emerging projects are in the early stages of development. There is a clear project goal, but they are not yet feature-complete and not stable.
 
-    https://raw.githubusercontent.com/ecmwf/codex/refs/heads/main/codex/Project%20Maturity/emerging_badge.svg
+    https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/emerging_badge.svg
 
 # Sandbox
 
-![Static Badge](./sandbox_badge.svg)
+![Static Badge](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/sandbox_badge.svg)
 
 Sandbox projects are experimental, proof-of-concept. Expect frequent changes, incomplete features and instability.
 
-    https://raw.githubusercontent.com/ecmwf/codex/refs/heads/main/codex/Project%20Maturity/sandbox_badge.svg
+    https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/sandbox_badge.svg
 
 # Archived
 
-![Static Badge](./archived_badge.svg)
+![Static Badge](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/archived_badge.svg)
 
 Projects that have reached the end of their lifecycle.
 They are no longer actively maintained or developed. 
 These projects may still be available for reference or historical purposes, but they should not be used for any active development or operational purposes.
 
-    https://raw.githubusercontent.com/ecmwf/codex/refs/heads/main/codex/Project%20Maturity/archived_badge.svg
+    https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity/archived_badge.svg


### PR DESCRIPTION
I went to copy the badge link over but somehow they 404 for me. I replaced them with the raw link generated by clicking the "raw" button on the file on github. I also added the full link to the badge so you can copy the full markup over to a README