### PR TITLE
Add Code of Conduct for ECMWF software development

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Code of Conduct
+
+## Our Pledge
+
+While developing software and services at ECMWF and with our community of Member and Cooperating States, we are
+committed to fostering an inclusive, respectful, and harassment-free community
+in line with [ECMWF's Open Source Principles](./Principles/open-source-principles.md),
+which are inspired by the [United Nations Open Source Principles](https://opensource.un.org/en/news/united-nations-open-source-principles).
+
+We pledge to make participation in our project and community a welcoming
+experience for everyone, regardless of age, body size, disability, ethnicity,
+gender identity and expression, level of experience, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community and the software
+- Showing empathy towards other community members
+- Acknowledging contributors and giving credit where due (ECMWF RISE principle)
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned with this Code of Conduct, or to temporarily or
+permanently ban any contributor for other behaviours that they deem
+inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — including the
+GitHub repository, issue tracker, pull requests, documentation, and any
+other communication channels used by the project. It also applies when an
+individual is representing the project or its community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported by contacting the development team via [software@ecmwf.int](mailto:software@ecmwf.int).
+All complaints will be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is obligated
+to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html,
+and informed by [ECMWF's Open Source Principles](./Principles/open-source-principles.md).

--- a/Principles/CODE_OF_CONDUCT.md
+++ b/Principles/CODE_OF_CONDUCT.md
@@ -4,7 +4,7 @@
 
 While developing software and services at ECMWF and with our community of Member and Cooperating States, we are
 committed to fostering an inclusive, respectful, and harassment-free community
-in line with [ECMWF's Open Source Principles](./Principles/open-source-principles.md),
+in line with [ECMWF's Open Source Principles](./open-source-principles.md),
 which are inspired by the [United Nations Open Source Principles](https://opensource.un.org/en/news/united-nations-open-source-principles).
 
 We pledge to make participation in our project and community a welcoming
@@ -63,4 +63,4 @@ to maintain confidentiality with regard to the reporter of an incident.
 This Code of Conduct is adapted from the
 [Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
 available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html,
-and informed by [ECMWF's Open Source Principles](./Principles/open-source-principles.md).
+and informed by [ECMWF's Open Source Principles](./open-source-principles.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Codex is a set of principles and guidelines for development of software and 
 
 # Contents
 
-- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Code of Conduct](./Principles/CODE_OF_CONDUCT.md)
 - [Principles](./Principles)
 - [Architectural Decision Records](./ADR)
 - [Repository Structure](./Repository%20Structure)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Codex is a set of principles and guidelines for development of software and 
 
 # Contents
 
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
 - [Principles](./Principles)
 - [Architectural Decision Records](./ADR)
 - [Repository Structure](./Repository%20Structure)


### PR DESCRIPTION
## Summary

- Adds a `CODE_OF_CONDUCT.md` under the `Principles/` directory, adapted from the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)
- Aligned with [ECMWF's Open Source Principles](./Principles/open-source-principles.md) and the [UN Open Source Principles](https://opensource.un.org/en/news/united-nations-open-source-principles)
- Based on the Code of Conduct introduced in [ecmwf/tensogram](https://github.com/ecmwf/tensogram) (see ecmwf/tensogram#37), with adjustments for the codex repo:
  - Links to Open Source Principles use relative paths (since codex is the source repo)
  - Fixed `emailto:` → `mailto:` typo from the original
- Links the Code of Conduct from the main README

## Context

As the codex defines standards for all ECMWF software development, having the Code of Conduct here establishes a single reference that individual projects (like tensogram) can point to, rather than each project maintaining its own copy. The file lives in `Principles/` alongside the existing Open Source Principles, since the Code of Conduct is a foundational principle rather than an operational guideline.

## Test plan

- [ ] Verify all relative links resolve correctly (e.g. `./open-source-principles.md` from within `Principles/`)
- [ ] Confirm `mailto:` link works in the enforcement section
- [ ] Review wording with the team for ECMWF-specific appropriateness